### PR TITLE
feat: add properties with headers

### DIFF
--- a/pkg/rabbix/rabbix.go
+++ b/pkg/rabbix/rabbix.go
@@ -1,8 +1,8 @@
 package rabbix
 
 type TestCase struct {
-	Name     string            `json:"name"`
-	RouteKey string            `json:"route_key"`
-	JSONPool map[string]any    `json:"json_pool"`
-	Headers  map[string]string `json:"headers"`
+	Name     string         `json:"name"`
+	RouteKey string         `json:"route_key"`
+	JSONPool map[string]any `json:"json_pool"`
+	Headers  map[string]any `json:"headers"`
 }

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -47,8 +47,13 @@ func (r *Request) Request(testCase rabbix.TestCase) (*http.Response, error) {
 		return nil, fmt.Errorf("erro ao serializar payload: %w", err)
 	}
 
+	properties := map[string]any{}
+	if len(testCase.Headers) > 0 {
+		properties["headers"] = testCase.Headers
+	}
+
 	requestBody := map[string]any{
-		"properties":       map[string]any{},
+		"properties":       properties,
 		"routing_key":      testCase.RouteKey,
 		"payload":          string(payloadBytes),
 		"payload_encoding": "string",
@@ -71,9 +76,6 @@ func (r *Request) Request(testCase rabbix.TestCase) (*http.Response, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	for key, value := range testCase.Headers {
-		req.Header.Set(key, value)
-	}
 
 	clientHttp := &http.Client{}
 	return clientHttp.Do(req)


### PR DESCRIPTION
**Título:**
Refatoração do envio de headers para o corpo da requisição RabbitMQ

**Descrição:**
Este PR modifica a forma como os headers são tratados na requisição HTTP enviada para o RabbitMQ.
Antes, os headers definidos em `testCase.Headers` eram enviados como cabeçalhos HTTP (`req.Header.Set`).
Agora, os headers foram incorporados dentro do campo `properties.headers` no corpo (`requestBody`), conforme esperado pela API HTTP do RabbitMQ.

**Alterações principais:**

- Removida a iteração `for key, value := range testCase.Headers` para adicionar headers na requisição HTTP.
- Adicionada a montagem de `properties` com `headers` dentro do `requestBody`.
- Mantida a autenticação básica (`Authorization`) e o cabeçalho `Content-Type`.

**Motivação:**
A API HTTP do RabbitMQ espera que headers customizados sejam enviados no campo `properties.headers` do JSON, não nos cabeçalhos HTTP da requisição. Essa alteração garante compatibilidade com o funcionamento correto da publicação de mensagens.

**Testes realizados:**

- Testado o envio de mensagens com headers customizados, validando que aparecem corretamente no `properties.headers` no RabbitMQ.
- Testado o comportamento com `testCase.Headers` vazio, garantindo que properties não inclui o campo headers.